### PR TITLE
Add basic skeleton for driver service

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/OscarMoya/Glubber
+
+go 1.21.3
+
+require github.com/gorilla/websocket v1.5.3

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=

--- a/pkg/model/driver_msg.go
+++ b/pkg/model/driver_msg.go
@@ -1,0 +1,36 @@
+package model
+
+type DriverMsgType string
+
+const (
+	// DriverLocationMsg is the message type for driver location updates
+	DriverLocationMsg DriverMsgType = "driver_location"
+	// DriveRequestMsg is the message type for passenger ride requests
+	DriveRequestMsg DriverMsgType = "drive_request"
+)
+
+type (
+
+	// BaseMessage is the base structure for all messages with a Type field
+	BaseMessage struct {
+		Type DriverMsgType `json:"type"`
+	}
+
+	// DriverLocation represents the location message from a driver
+	DriverLocation struct {
+		BaseMessage
+		DriverID  string  `json:"driver_id"`
+		Latitude  float64 `json:"latitude"`
+		Longitude float64 `json:"longitude"`
+	}
+
+	// DriveRequest represents a ride request message from a passenger
+	DriveRequest struct {
+		BaseMessage
+		PassengerID string  `json:"passenger_id"`
+		PickupLat   float64 `json:"pickup_latitude"`
+		PickupLng   float64 `json:"pickup_longitude"`
+		DropLat     float64 `json:"drop_latitude"`
+		DropLng     float64 `json:"drop_longitude"`
+	}
+)

--- a/svc/driver/main.go
+++ b/svc/driver/main.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+const (
+	serveURL  = "localhost:8081"
+	driverURI = "v1/driver/"
+)
+
+var (
+	upgrader = websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool {
+			return true
+		},
+	}
+
+	locationURI = fmt.Sprintf("%sws", driverURI)
+)
+
+func main() {
+	http.HandleFunc(locationURI, handleDriverConnections)
+	log.Printf("HTTP server started on %s\n", serveURL)
+	err := http.ListenAndServe(serveURL, nil)
+	if err != nil {
+		log.Fatal("ListenAndServe: ", err)
+	}
+}
+
+func handleDriverConnections(w http.ResponseWriter, r *http.Request) {
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	in := make(chan []byte, 256)
+	out := make(chan []byte, 256)
+
+	defer ws.Close()
+
+	ctx, cancel := context.WithCancel(r.Context())
+	defer cancel()
+
+	go driverSvcLoop(ctx, in, out)
+
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Driver service loop done")
+			return
+		case msg := <-out:
+			err := ws.WriteMessage(websocket.TextMessage, msg)
+			if err != nil {
+				// If there is an error writing to the websocket, log it and continue
+				// We may want to handle this differently in a production system
+				log.Println("write:", err)
+				continue
+			}
+		default:
+			// TODO: check message types
+			_, msg, err := ws.ReadMessage()
+			if err != nil {
+				log.Println("read:", err)
+				break
+			}
+			log.Printf("recv: %s", msg)
+			in <- msg
+		}
+
+	}
+}

--- a/svc/driver/ws_handler.go
+++ b/svc/driver/ws_handler.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+
+	"github.com/OscarMoya/Glubber/pkg/model"
+)
+
+func driverSvcLoop(ctx context.Context, in <-chan []byte, out chan<- []byte) {
+	for {
+		select {
+		case <-ctx.Done():
+			log.Println("Driver service loop done")
+			return
+		case msg := <-in:
+			// TODO: Stablish timeout for this OPS
+			backendCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			var baseMessage model.BaseMessage
+			if err := json.Unmarshal(msg, &baseMessage); err != nil {
+				log.Println("unmarshal base message:", err)
+				continue
+			}
+
+			switch baseMessage.Type {
+			case model.DriverLocationMsg:
+				var loc model.DriverLocation
+				if err := json.Unmarshal(msg, &loc); err != nil {
+					log.Println("unmarshal driver location:", err)
+					continue
+				}
+				handleDriverLocation(backendCtx, out, loc)
+
+			case model.DriveRequestMsg:
+				var req model.DriveRequest
+				if err := json.Unmarshal(msg, &req); err != nil {
+					log.Println("unmarshal drive request:", err)
+					continue
+				}
+				handleDriveRequest(backendCtx, out, req)
+
+			default:
+				log.Println("Unknown message type:", baseMessage.Type)
+			}
+		}
+	}
+}
+
+func handleDriverLocation(ctx context.Context, out chan<- []byte, loc model.DriverLocation) {
+	log.Printf("Received driver location: %+v\n", loc)
+}
+
+func handleDriveRequest(ctx context.Context, out chan<- []byte, req model.DriveRequest) {
+	log.Printf("Received drive request: %+v\n", req)
+}


### PR DESCRIPTION
Added a simple WebSocket main loop with a couple of placeholder functions to depict the basic workflow of messages.

The main idea is to provide a main loop with wrapper functions that run in separate goRoutines.
These functions will be then handled synchronously in the service layer and will provide the result with an output channel of type []byte

The basic error handling and process needs to be polished but the main workflow seems solid for the moment